### PR TITLE
feat: optimized the toolbar status display when pressing the space bar

### DIFF
--- a/packages/core/src/canvas_dragger.ts
+++ b/packages/core/src/canvas_dragger.ts
@@ -1,6 +1,11 @@
+import { EventEmitter } from '@suika/common';
 import { type IPoint } from '@suika/geo';
 
 import { type Editor } from './editor';
+
+interface Events {
+  activeDrag(press: boolean): void;
+}
 
 /**
  * drag canvas
@@ -10,17 +15,28 @@ export class CanvasDragger {
   private _active = false;
   private inactiveAfterPointerUp = false;
   private isEnableDragCanvasBySpace = true;
-
+  private eventEmitter = new EventEmitter<Events>();
   private _isPressing = false;
   private isDragging = false;
   private startPoint: IPoint = { x: 0, y: 0 };
   private startViewportPos: IPoint = { x: 0, y: 0 };
+
+  on<K extends keyof Events>(eventName: K, handler: Events[K]) {
+    this.eventEmitter.on(eventName, handler);
+  }
+  off<K extends keyof Events>(eventName: K, handler: Events[K]) {
+    this.eventEmitter.off(eventName, handler);
+  }
 
   isPressing() {
     return this._isPressing;
   }
 
   private handleSpaceToggle = (isSpacePressing: boolean) => {
+    this.eventEmitter.emit(
+      'activeDrag',
+      this.isEnableDragCanvasBySpace && isSpacePressing,
+    );
     if (!this.isEnableDragCanvasBySpace) return;
     if (isSpacePressing) {
       this.active();

--- a/packages/suika/src/components/Header/components/Toolbar/Toolbar.tsx
+++ b/packages/suika/src/components/Header/components/Toolbar/Toolbar.tsx
@@ -22,6 +22,7 @@ import { Menu } from './menu';
 export const ToolBar = () => {
   const editor = useContext(EditorContext);
   const intl = useIntl();
+  const [isSpaceDrag, setIsSpaceDrag] = useState(false);
   const [currTool, setCurrTool] = useState('');
   const [enableTools, setEnableTools] = useState<string[]>([]);
   const [isPathEditorActive, setIsPathEditorActive] = useState(false);
@@ -42,13 +43,19 @@ export const ToolBar = () => {
         setEnableTools(tools);
       };
 
+      const onActiveDrag = (enable: boolean) => {
+        setIsSpaceDrag(enable);
+      };
+
       editor.toolManager.on('switchTool', onSwitchTool);
       editor.toolManager.on('changeEnableTools', onChangeEnableTools);
       editor.pathEditor.on('toggle', onTogglePathEditor);
+      editor.canvasDragger.on('activeDrag', onActiveDrag);
       return () => {
         editor.toolManager.off('switchTool', onSwitchTool);
         editor.toolManager.off('changeEnableTools', onChangeEnableTools);
         editor.pathEditor.off('toggle', onTogglePathEditor);
+        editor.canvasDragger.off('activeDrag', onActiveDrag);
       };
     }
   }, [editor]);
@@ -115,7 +122,11 @@ export const ToolBar = () => {
         return (
           <ToolBtn
             key={tool.name}
-            className={classNames({ active: currTool === tool.name })}
+            className={classNames({
+              active: [currTool, isSpaceDrag ? 'dragCanvas' : ''].includes(
+                tool.name,
+              ),
+            })}
             tooltipContent={intl.formatMessage({ id: tool.intlId })}
             hotkey={tool.hotkey}
             onMouseDown={() => {


### PR DESCRIPTION
当按住空格键时工具栏状态选中拖拽画布icon，空格键松开时返回上一次选中的工具icon。  
当鼠标或h快捷键选中“拖拽画布”时，按住空格键不会改变工具栏选中状态。
![image](https://github.com/F-star/suika/assets/52070630/e326eedf-81be-496e-a6e4-fab9efb77757)
