### PR TITLE
fix: graph的bbox问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.history

--- a/packages/core/src/graphs/graph/graph.ts
+++ b/packages/core/src/graphs/graph/graph.ts
@@ -8,6 +8,7 @@ import {
 } from '@suika/common';
 import {
   boxToRect,
+  getRectByTwoPoint,
   getTransformAngle,
   getTransformedSize,
   type IBox,
@@ -165,7 +166,7 @@ export class Graph<ATTRS extends GraphAttrs = GraphAttrs> {
    * AABB (axis-aligned bounding box), without considering strokeWidth)
    * Consider rotation (orthogonal bounding box after rotation)
    */
-  private _calcBbox(padding?: number): Readonly<IBox> {
+  protected _calcBbox(padding?: number): Readonly<IBox> {
     let x = 0;
     let y = 0;
     let width = this.attrs.width;
@@ -209,11 +210,17 @@ export class Graph<ATTRS extends GraphAttrs = GraphAttrs> {
   }
 
   getBboxVerts(): IPoint[] {
+    const { minX, minY, maxX, maxY } = this.getBbox();
+    const { width, height } = getRectByTwoPoint(
+      { x: minX, y: maxY },
+      { x: maxX, y: minY },
+    );
+
     const rect = {
       x: 0,
       y: 0,
-      width: this.attrs.width,
-      height: this.attrs.height,
+      width,
+      height,
     };
     return rectToVertices(rect, this.attrs.transform);
   }
@@ -243,7 +250,9 @@ export class Graph<ATTRS extends GraphAttrs = GraphAttrs> {
   }
 
   getTransformedSize() {
-    return getTransformedSize(this.attrs);
+    // 放弃使用W、H，使用bbox的W、H
+    const rect = boxToRect(this.getBbox());
+    return getTransformedSize({ ...rect, transform: this.attrs.transform });
   }
 
   getCenter(): IPoint {

--- a/packages/core/src/graphs/regular_polygon.ts
+++ b/packages/core/src/graphs/regular_polygon.ts
@@ -152,6 +152,11 @@ export class RegularPolygon extends Graph<RegularPolygonAttrs> {
     ];
   }
 
+  override shouldUpdateBbox(attrs: Partial<RegularPolygonAttrs> & IGraphOpts) {
+    // TODO: if x, y, width, height value no change, bbox should not be updated
+    return attrs.count !== undefined || super.shouldUpdateBbox(attrs);
+  }
+
   override updateAttrs(
     partialAttrs: Partial<RegularPolygonAttrs> & IGraphOpts,
     options?: { finishRecomputed?: boolean },
@@ -178,5 +183,34 @@ export class RegularPolygon extends Graph<RegularPolygonAttrs> {
     return `<polygon points="${points
       .map((p) => `${p.x},${p.y}`)
       .join(' ')}" transform="matrix(${tf.join(' ')})"`;
+  }
+
+  protected override _calcBbox() {
+    const tf = new Matrix(...this.attrs.transform);
+    const vertices = getRegularPolygon(this.getSize(), this.attrs.count).map(
+      (item) => {
+        const pos = tf.apply(item);
+        return { x: pos.x, y: pos.y };
+      },
+    );
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const vertex of vertices) {
+      minX = Math.min(minX, vertex.x);
+      minY = Math.min(minY, vertex.y);
+      maxX = Math.max(maxX, vertex.x);
+      maxY = Math.max(maxY, vertex.y);
+    }
+
+    return {
+      minX,
+      minY,
+      maxX,
+      maxY,
+    };
   }
 }

--- a/packages/core/src/selected_box.ts
+++ b/packages/core/src/selected_box.ts
@@ -34,11 +34,11 @@ export class SelectedBox {
     if (count > 0) {
       if (count === 1) {
         const selectedGraph = selectedElements.getItems()[0];
-        const rect = selectedGraph.getSize();
+        const rect = selectedGraph.getBbox();
         this.box = {
-          width: rect.width,
-          height: rect.height,
-          transform: selectedGraph.attrs.transform!,
+          width: Math.abs(rect.maxX - rect.minX),
+          height: Math.abs(rect.maxY - rect.minY),
+          transform: [1, 0, 0, 1, rect.minX, rect.minY],
         };
       } else {
         const rect = selectedElements.getBbox()!;

--- a/packages/core/src/service/mutate_graphs_and_record.ts
+++ b/packages/core/src/service/mutate_graphs_and_record.ts
@@ -1,3 +1,5 @@
+import { boxToRect } from '@suika/geo';
+
 import { SetGraphsAttrsCmd } from '../commands/set_elements_attrs';
 import { type Editor } from '../editor';
 import { type Graph, type Rect } from '../graphs';
@@ -61,7 +63,9 @@ export const MutateGraphsAndRecord = {
       width: el.attrs.width,
     }));
     graphs.forEach((graph) => {
-      graph.updateAttrs({ width });
+      // 因为改成bbox的宽，所以要这里的Width指的是bbox的宽，需要装换一下才是attrs的width
+      const proportion = graph.attrs.width / boxToRect(graph.getBbox()).width;
+      graph.updateAttrs({ width: width * proportion });
     });
     editor.commandManager.pushCommand(
       new SetGraphsAttrsCmd(
@@ -83,8 +87,10 @@ export const MutateGraphsAndRecord = {
       height: el.attrs.height,
     }));
     graphs.forEach((graph) => {
+      // 因为改成bbox的高，所以要这里的Height指的是bbox的高，需要装换一下才是attrs的height
+      const proportion = graph.attrs.height / boxToRect(graph.getBbox()).height;
       graph.updateAttrs({
-        height,
+        height: height * proportion,
       });
     });
     editor.commandManager.pushCommand(


### PR DESCRIPTION
西瓜哥流弊！！！
在拜读过程中，感觉多边形的bbox有点不符合直觉，直接使用attrs中的width、height来计算的话会导致下图的误解，不能真实反映多边形的实际宽高。例如三角形，按照源码中三角形三点的计算方式，能得到一个等边三角形，但是实际上根本不存在W\H为100的等边三角形。

![image](https://github.com/F-star/suika/assets/39414502/59991d6a-8129-4ba7-9445-4380de5b0796)

**我的改动**
将bbox的计算方式改为由多边形实际的点数据来计算，并将elementInfoCard中W、H的计算方式改为bbox的W、H。效果如图

![image](https://github.com/F-star/suika/assets/39414502/46710f40-1d69-410a-b13d-96cbb9f4eaaf)

这样也比较符合直觉。

**改动思路**
1、通过在regular_polygon中重写graph中的_calcBbox方法，修改多边形的bbox计算方式，由实际的点数组得到。
2、在elementInfoCard中修改width、height的getXXX(),每次都由bbox计算得到。对应的set方法改为attrs.width\height由graph实际的宽换算得到，换算比例是：attrs.width / (bbox的width)。这样不破坏attrs中width、height的本来意义，应该不造成破坏性改动。
