### PR TITLE
fix: 多边形高亮的transform错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.history

--- a/packages/core/src/graphs/regular_polygon.ts
+++ b/packages/core/src/graphs/regular_polygon.ts
@@ -102,7 +102,6 @@ export class SuikaRegularPolygon extends SuikaGraphics<RegularPolygonAttrs> {
       overrideStyle || this.attrs;
 
     ctx.save();
-    // 优先使用WorldTransform
     ctx.transform(...(transform ?? attrs.transform));
 
     const points = this.getPoints();

--- a/packages/core/src/graphs/regular_polygon.ts
+++ b/packages/core/src/graphs/regular_polygon.ts
@@ -98,10 +98,12 @@ export class SuikaRegularPolygon extends SuikaGraphics<RegularPolygonAttrs> {
     },
   ) {
     const attrs = this.attrs;
-    const { fill, strokeWidth, stroke } = overrideStyle || this.attrs;
+    const { fill, strokeWidth, stroke, transform } =
+      overrideStyle || this.attrs;
 
     ctx.save();
-    ctx.transform(...attrs.transform);
+    // 优先使用WorldTransform
+    ctx.transform(...(transform ?? attrs.transform));
 
     const points = this.getPoints();
 
@@ -130,6 +132,7 @@ export class SuikaRegularPolygon extends SuikaGraphics<RegularPolygonAttrs> {
         }
       }
     }
+
     if (strokeWidth) {
       ctx.lineWidth = strokeWidth;
       for (const paint of stroke ?? []) {


### PR DESCRIPTION
修复在组合中的多边形hover高亮位置有误。系没有使用传入的worldTransform导致